### PR TITLE
feat: 높낮이 변화에 따른 애니메이션 추가(requireAnimationFrame; a.k.a. rAF)

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -209,7 +209,8 @@ article#showSortingNumbers {
   margin: 8px;
   background-color: whitesmoke;
   color: black;
-  font-size: 22px;
+  font-size: 18px;
+  font-weight: 700;
 }
 
 .intro-animation {

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -83,7 +83,6 @@ const pickSortingAlgorithmCallback = (e) => {
       return;
     }
 
-    // createBarArray(numberArray, 1);
     pickSortingAlgorithm(selectedSortOption, numberArray);
   }
 };

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -143,7 +143,7 @@ const createBarArray = (array, step, sortType, fixedIndexArray, beingSortedIndex
       newElement.textContent = textContent;
       const percentHeight = (textContent / maxNumber) * 100;
       newElement.style.height = `${percentHeight}%`;
-      newElement.style.transition = 'all 1s';
+      newElement.style.transition = 'all 1.5s';
       newElement.classList.add('sorting-array-element');
 
       newElement.id = number;
@@ -209,7 +209,7 @@ const animation = async (generator, sortType) => {
       createBarArray(array, step, sortType, fixedIndexArray, beingSortedIndexArray);
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
   }
 
   const $numberBars = document.querySelectorAll('.sorting-array-element');

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -22,18 +22,6 @@ const SORT_OPTIONS = Object.freeze({
 
 let selectedSortOption = SORT_OPTIONS.BUBBLE;
 
-class PreviousArray {
-  constructor() {
-    this.value = null;
-  }
-
-  setPreviousArray(array) {
-    this.value = array.slice();
-  }
-}
-
-const previousArray = new PreviousArray();
-
 const changeNumberInput = (e) => {
   const regExp = /^[0-9 ]*$/;
   const currentValue = e.target.value;
@@ -100,15 +88,30 @@ const pickSortingAlgorithmCallback = (e) => {
   }
 };
 
+const checkPreviousArray = () => {
+  let previousArray = null;
+
+  return {
+    getPreviousArray() {
+      return previousArray;
+    },
+    setPreviousArray(array) {
+      previousArray = array.slice();
+    },
+  };
+};
+
+const { getPreviousArray, setPreviousArray } = checkPreviousArray();
+
 /**
  * DOM 에 접근하여 배열에 맞는 막대를 그려주는 함수입니다.
  * @param {Array<Number>} array
  */
-const createBarArray = (array, step, fixedIndexArray, beingSortedIndexArray, tmpInfo) => {
+const createBarArray = (array, step, sortType, fixedIndexArray, beingSortedIndexArray, tmpInfo) => {
   $showSortingNumbers.innerHTML = '';
   const maxNumber = Math.max(...array);
 
-  if ((!tmpInfo && step === 1) || tmpInfo) {
+  if (step === 1 || sortType === SORT_OPTIONS.INSERTION || sortType === SORT_OPTIONS.MERGE) {
     array.forEach((number, index) => {
       const newElement = document.createElement('div');
       const textContent = tmpInfo ? (tmpInfo[0] === index ? tmpInfo[1] : number) : number;
@@ -129,10 +132,12 @@ const createBarArray = (array, step, fixedIndexArray, beingSortedIndexArray, tmp
       newElement.dataset.index = index;
       $showSortingNumbers.appendChild(newElement);
 
-      previousArray.setPreviousArray(array);
+      setPreviousArray(array);
     });
   } else {
-    previousArray.value.forEach((number, index) => {
+    const previousArray = getPreviousArray();
+
+    previousArray.forEach((number, index) => {
       const newElement = document.createElement('div');
       const textContent = tmpInfo ? (tmpInfo[0] === index ? tmpInfo[1] : number) : number;
       newElement.textContent = textContent;
@@ -167,7 +172,7 @@ const createBarArray = (array, step, fixedIndexArray, beingSortedIndexArray, tmp
         element.classList.add('being-sorted-highest');
       }
 
-      previousArray.setPreviousArray(array);
+      setPreviousArray(array);
     });
   }
 };
@@ -196,12 +201,12 @@ const animation = async (generator, sortType) => {
     const beingSortedIndexArray = checkWhichBeingSorted(yieldArray, sortType);
 
     if (sortType === SORT_OPTIONS.INSERTION) {
-      createBarArray(array, step, fixedIndexArray, beingSortedIndexArray, [
+      createBarArray(array, step, sortType, fixedIndexArray, beingSortedIndexArray, [
         yieldArray[2],
         yieldArray[3],
       ]);
     } else {
-      createBarArray(array, step, fixedIndexArray, beingSortedIndexArray);
+      createBarArray(array, step, sortType, fixedIndexArray, beingSortedIndexArray);
     }
 
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -100,7 +100,7 @@ const createBarArray = (array, fixedIndexArray, beingSortedIndexArray, tmpInfo) 
     const newElement = document.createElement('div');
     const textContent = tmpInfo ? (tmpInfo[0] === index ? tmpInfo[1] : number) : number;
     newElement.textContent = textContent;
-    const percentHeight = (textContent / maxNumber) * 80;
+    const percentHeight = (textContent / maxNumber) * 100;
     newElement.style.height = `${percentHeight}%`;
     newElement.classList.add('sorting-array-element');
 

--- a/javascript/sort/merge.js
+++ b/javascript/sort/merge.js
@@ -4,8 +4,6 @@ function* mergeSortingAlgorithm(array) {
   yield* mergeFunction(result);
 }
 
-export default mergeSortingAlgorithm;
-
 function* divideFunction(array) {
   if (array.length === 1) return array;
 
@@ -88,7 +86,7 @@ function* mergeFunction(array) {
   if (nullCount > 1) {
     yield* mergeFunction(result);
   }
-  console.log(result);
+
   return result;
 }
 
@@ -118,5 +116,8 @@ const sortingFunction = (array) => {
 
     start = end;
   }
+
   return array;
 };
+
+export default mergeSortingAlgorithm;


### PR DESCRIPTION
## 📖 작업 내용

### `checkPreviousArray` 함수 구현(클로저 적용)
- 클로저로 지역변수 `previousArray`에 대한 getter와 setter 함수를 리턴하여 사용

### `animatingByHeight` 함수 구현(requireAnimationFrame 재귀)

### sortType에 따른 애니메이션 적용/미적용 구분
- 삽입 정렬의 경우에는 해당 애니메이션을 적용하니까, "삽입" 느낌이 없어져서 애니메이션 미적용함
- 병렬 정렬의 경우에는 구현 방식 때문에 버그와 같은 동작이 보여서 적용하지 않음
  - 추후 도전해보는 것으로 해야할 것 같음

### step 변수 사용
- 첫 번째 step(렌더링)일 경우에는 이전과 동일한 방식으로 렌더링
- 버블, 선택 정렬의 경우, step >= 2부터 클로저로 기억하고 있던 예전 배열을 가지고 렌더링 후
- `createBarArray` 함수에 파라미터로 들어온 array 배열과의 차이에 만큼 높이 변화를 transition Animation 적용


## ✅ PR 포인트

- 높낮이 변화에 따른 애니메이션 추가(버블, 선택 정렬에 사용)
  - `requireAnimationFrame` 사용
  - https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame

## 📸 스크린샷

![Bubble-heightEffectAnimation](https://github.com/user-attachments/assets/3c11b19c-448a-420a-96d7-3d75ea03e243)
